### PR TITLE
[WIP] Implement Custom Command

### DIFF
--- a/src/modes/command/client/commands/misc.js
+++ b/src/modes/command/client/commands/misc.js
@@ -28,3 +28,25 @@ export function passAllKeys (event) {
   event.passKeyType = 'all'
   return 'Pass'
 }
+
+// TODO: Get from options.
+let customCommands = {
+  toHttps: {
+    preventDefault: true, // The default.
+    code:
+      'document.location = document.location.href.replace(/^http:/, "https:")'
+  }
+}
+
+// TODO reduce amount of visible internal state.
+function trampoline (_src, event) {
+  eval(_src)
+}
+
+export function customCommand (id, event) {
+  let impl = customCommands[id]
+  console.log('Custom command', id, impl)
+
+  if (impl.preventDefault) event.preventDefault()
+  return trampoline(impl.code, event)
+}

--- a/src/modes/command/client/trie.js
+++ b/src/modes/command/client/trie.js
@@ -25,6 +25,13 @@ export function advanceInputTrie (event) {
     default:
       event.preventDefault()
       event.stopImmediatePropagation()
-      return commands[command](event) || 'Same'
+      var cmd
+      if (command.startsWith('customCommand_')) {
+        let id = command.slice(14) // Drop prefix.
+        cmd = commands.customCommand.bind(null, id)
+      } else {
+        cmd = commands[command]
+      }
+      return cmd(event) || 'Same'
   }
 }

--- a/src/options/Keybindings/config.json
+++ b/src/options/Keybindings/config.json
@@ -485,6 +485,17 @@
       "label": "Activate Clipboard in Incognito Window",
       "key": "clipboardIncognitoWindow",
       "default": []
+    },
+    {
+      "type": "header",
+      "label": "Custom"
+    },
+    {
+      "comment": "TODO: generate dynamically",
+      "type": "keybinding",
+      "label": "Custom Command",
+      "key": "customCommand_toHttps",
+      "default": []
     }
   ]
 }

--- a/src/options/Keybindings/default.json
+++ b/src/options/Keybindings/default.json
@@ -198,7 +198,8 @@
             { "code": "KeyY", "key": "y" },
             { "code": "KeyN", "key": "N", "shiftKey": true }
           ]
-        ]
+        ],
+        "customCommand_toHttps": []
       }
     },
     {
@@ -373,7 +374,8 @@
             { "code": "KeyY", "key": "y" },
             { "code": "KeyN", "key": "N", "shiftKey": true }
           ]
-        ]
+        ],
+        "customCommand_toHttps": []
       }
     },
     {
@@ -505,7 +507,8 @@
             { "code": "KeyY", "key": "y" },
             { "code": "KeyN", "key": "N", "shiftKey": true }
           ]
-        ]
+        ],
+        "customCommand_toHttps": []
       }
     },
     {
@@ -634,7 +637,8 @@
           [{ "code": "KeyP", "key": "P", "shiftKey": true }]
         ],
         "clipboardNewWindow": [],
-        "clipboardIncognitoWindow": []
+        "clipboardIncognitoWindow": [],
+        "customCommand_toHttps": []
       }
     }
   ]


### PR DESCRIPTION
This is a very basic implementation but it is actually pretty close. (It turns out calling eval on a string isn't too difficult).

What rocks:
- Simple
- Powerful.

What sucks:
- Custom function key is hidden in the command name. This is because currently commands carry not config at all. It would probably be more "proper" to give each command an argument object so that they can be configured. If this is done then the id can be passed in the argument and the string split hack can be removed.
- Command has access to a lot more then indended. Right now I want to expose "event" and the standard web globals to the code but as it stands I can't think of a way to whitelist things it has access to. I could try putting it in it's own module but IIUC the bundler basically prevents that from acutally restricting access at all. I might be able to use "let global_eval = eval; global_eval(code)" but I will have to take another look at the bundler to see what globals it leaks.
- Content eval only. Mozilla won't let us eval stuff in the background page so we can't do stuff there. I guess we will just have to expose functionality manually overtime (which really nullifies the security benifit anyways 😢) maybe we can start making a self-hosted build that can do fun things, but that is largely independant of this feature.

What needs to be done:
- [ ] Source the commands from the UI. Right now I have just hardcoded one command for testing. This works but the functionality is pointless unless the user can acutally configure it.
- [ ] Allow a dynamic set of commands to be configured. Right now I have just hardcoded one into the options.

Fixes #45 