### PR TITLE
Add Blacklist feature fixes #192

### DIFF
--- a/src/client/modes.js
+++ b/src/client/modes.js
@@ -4,10 +4,13 @@ import {
   passDOMEventToMiddleware,
   middlewareOnOptionsChange
 } from './middleware'
+import { anyMatch } from '../lib/regex'
+import { storageGet } from '../storage/storage'
 
 /** The active mode of the Modes state machine */
 let currentMode
 let modes = {}
+let currentOptions = {}
 /** whether saka key is enabled or not */
 let enabled = false
 
@@ -164,8 +167,18 @@ export function changeMode (modeChangeEvent) {
       throw Error('Called changeMode but failed to provide a type')
     }
   }
+  let patterns = modeChangeEvent.options.blacklist
+    .split(',')
+    .map(patternStr => {
+      patternStr = patternStr.trim()
+      return new RegExp(patternStr)
+    })
   if (enabled) {
-    setMode(modeChangeEvent.mode, modeChangeEvent)
+    if (anyMatch(patterns, window.location.href) === true) {
+      setMode('Disabled', modeChangeEvent)
+    } else {
+      setMode(modeChangeEvent.mode, modeChangeEvent)
+    }
   }
 }
 

--- a/src/lib/regex.js
+++ b/src/lib/regex.js
@@ -1,0 +1,16 @@
+/**
+ * This file concerns itself with handling user inputed RegExp
+ */
+
+/**
+ * Determine if string matches any pattern in patterns array 
+ *
+ * @export
+ * @param {Regex[]} patterns Array of regex patterns
+ * @param {String} str String to check patterns against
+ * @returns {Boolean} True if string matches at least one pattern in list
+ */
+export function anyMatch (patterns, str) {
+  if (patterns.find(pattern => str.match(pattern))) return true
+  else return false
+}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -2,7 +2,14 @@
 export function posMod (n, m) {
   return (n % m + m) % m
 }
-
+/**
+ * Return copy of object that contains only the attributes specified in key array 
+ * 
+ * @param {Object} object Object that attributes are copied from
+ * @param {String[]} keys String array of attributes to copy
+ * @throws {Error} Object does not contain attribute key
+ * @returns {Object} Object that contains only the attributes specified in key array
+ */
 export function getAttributes (object, keys) {
   const output = {}
   keys.forEach(key => {

--- a/src/options/Blacklist/config.json
+++ b/src/options/Blacklist/config.json
@@ -1,0 +1,10 @@
+{
+  "options": [
+    {
+      "type": "textarea",
+      "label": "Comma Seperated Regex Blacklist",
+      "key": "blacklist",
+      "default": ""
+    }
+  ]
+}

--- a/src/options/Blacklist/default.json
+++ b/src/options/Blacklist/default.json
@@ -1,0 +1,11 @@
+{
+  "name": "Blacklist",
+  "profiles": [
+    {
+      "name": "default",
+      "options": {
+        "blacklist": "google.com,duck,.io"
+      }
+    }
+  ]
+}

--- a/src/options/Blacklist/default.json
+++ b/src/options/Blacklist/default.json
@@ -4,7 +4,7 @@
     {
       "name": "default",
       "options": {
-        "blacklist": "google.com,duck,.io"
+        "blacklist": ""
       }
     }
   ]

--- a/src/options/Blacklist/index.js
+++ b/src/options/Blacklist/index.js
@@ -2,7 +2,7 @@ import { getAttributes } from 'lib/util'
 
 export default (options, config) => {
   const backgroundOptions = getAttributes(options, ['blacklist'])
-  const clientOptions = {}
+  const clientOptions = getAttributes(options, ['blacklist'])
   const errors = {}
   return { backgroundOptions, clientOptions, errors }
 }

--- a/src/options/Blacklist/index.js
+++ b/src/options/Blacklist/index.js
@@ -1,0 +1,8 @@
+import { getAttributes } from 'lib/util'
+
+export default (options, config) => {
+  const backgroundOptions = getAttributes(options, ['blacklist'])
+  const clientOptions = {}
+  const errors = {}
+  return { backgroundOptions, clientOptions, errors }
+}

--- a/src/storage/transform.js
+++ b/src/storage/transform.js
@@ -1,10 +1,12 @@
 import transformGeneral from 'options/General'
 import transformKeybindings from 'options/Keybindings'
 import transformAppearance from 'options/Appearance'
+import transformBlacklist from 'options/Blacklist'
 const transforms = {
   General: transformGeneral,
   Keybindings: transformKeybindings,
-  Appearance: transformAppearance
+  Appearance: transformAppearance,
+  Blacklist: transformBlacklist
 }
 export const categories = Object.keys(transforms)
 


### PR DESCRIPTION
Allow the user to specify cites that Saka-key will be disabled on. This is done though the input of comma separated regular expressions. For example, if  "^https://google.com, git" is the input all pages that start with "https://google.com" or contain the "git" anywhere in the url will not have any Saka-key bindings.
 
I still need to add information to the tutorial (git-book), I am going to being doing that now and will make another pull request when finished.