### PR TITLE
Fix issue #156

### DIFF
--- a/src/client/gui.js
+++ b/src/client/gui.js
@@ -7,6 +7,7 @@ width: 100%;
 height: 100%;
 z-index: 2147483647;
 opacity: 1;
+background-color: transparent;
 pointer-events: none;`
 
 document.documentElement.appendChild(guiRoot)


### PR DESCRIPTION
On some sites, saka-gui-root was covering the page, because some styles of that page were applied to saka-gui-root. One such page is for example https://validator.w3.org/. The page is setting a default background-color of white on most HTML elements including the div of saka-gui-root.

By setting the background-color explicitly to transparent, the background styles of the site don't apply to saka-gui-root anymore.

I don't know if there is an even better way to fix this, but this seemed like the obvious way to solve this problem.