### PR TITLE
Fix a bug in Firefox with scrolling half pages

### DIFF
--- a/src/modes/command/client/commands/scroll/index.js
+++ b/src/modes/command/client/commands/scroll/index.js
@@ -31,16 +31,18 @@ export function scrollPageUp () {
 }
 
 export function scrollHalfPageDown () {
-  scrollBy({
-    top: innerHeight / 2,
-    behavior
+  scrollTo({
+    top: window.pageYOffset + window.innerHeight / 2,
+    left: 0,
+    behavior: behavior
   })
 }
 
 export function scrollHalfPageUp () {
-  scrollBy({
-    top: -innerHeight / 2,
-    behavior
+  scrollTo({
+    top: window.pageYOffset - window.innerHeight / 2,
+    left: 0,
+    behavior: behavior
   })
 }
 

--- a/src/modes/command/client/commands/scroll/index.js
+++ b/src/modes/command/client/commands/scroll/index.js
@@ -33,7 +33,6 @@ export function scrollPageUp () {
 export function scrollHalfPageDown () {
   scrollTo({
     top: window.pageYOffset + window.innerHeight / 2,
-    left: 0,
     behavior: behavior
   })
 }
@@ -41,7 +40,6 @@ export function scrollHalfPageDown () {
 export function scrollHalfPageUp () {
   scrollTo({
     top: window.pageYOffset - window.innerHeight / 2,
-    left: 0,
     behavior: behavior
   })
 }


### PR DESCRIPTION
In newer Firefox versions (around version 63), the window.scrollBy call
sometimes does not do anything at all, and later on will scroll the page
twice. This causes erratic behaviour when using half page scrolling with
Saka key.

I have not been able to determine when exactly, or why the scrollBy call
sometimes doesn't work, but changing the call to scrollTo does prevent
the bug from showing up.

Untested in other browsers, but behaviour should be mostly unchanged.