### PR TITLE
Fix a typo roboto, code had ".tff", instead of the correct ".ttf"

### DIFF
--- a/manifest/common.json
+++ b/manifest/common.json
@@ -41,7 +41,7 @@
     "content_script_loader.js.map",
     "options.js.map",
     "info.js.map",
-    "Roboto-Regular.tff",
+    "Roboto-Regular.ttf",
     "config_basic.json",
     "config_command.json",
     "config_developer.json",

--- a/src/modes/hints/client/HintRenderer.js
+++ b/src/modes/hints/client/HintRenderer.js
@@ -28,8 +28,8 @@ export function setHintRenderSettings ({
 @font-face {
   font-family: Roboto; -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased;
   font-style: normal; font-weight: normal; src: url(${chrome.runtime.getURL(
-    'Roboto-Regular.tff'
-  )}) format('tff');
+    'Roboto-Regular.ttf'
+  )}) format('ttf');
 }
 .saka-hint-body {
   ${hintCSS}


### PR DESCRIPTION
Here are the steps to identify the problem:

1) In Firefox debug console with some website, this problem creates warnings such as
    `downloadable font: no supported format found (font-family: "Roboto" style:normal weight:400 stretch:100 src index:1) source: (end of source list)`

2) In Stylesheet editor this manifests itself as something like:
```css
    @font-face {
      font-family: Roboto; -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased;
      font-style: normal; font-weight: normal; src: url(moz-extension://93af..............93c24/Roboto-Regular.tff) format('tff');
    }
```

3) Opening `moz-extension://93af..............93c24/Roboto-Regular.tff` gives an error
4) Opening `moz-extension://93af..............93c24/Roboto-Regular.ttf` gives a font!

Therefore I suggest this fix.
Hopefully it will be applied even if it's not an urgent PR.