### PR TITLE
ensure hints are only generated from list of unique characters

### DIFF
--- a/src/modes/hints/background/index.js
+++ b/src/modes/hints/background/index.js
@@ -26,7 +26,8 @@ export default {
         msg(currentTabTarget, 'exitHintsMode', nextMode)
         // If multiple hints, trigger hint rendering
       } else {
-        const hintStrings = generateHintStrings(hintChars, totalHints)
+        const uniqueChars = String.prototype.concat(...new Set(hintChars))
+        const hintStrings = generateHintStrings(uniqueChars, totalHints)
         let offset = 0
         hintsPerFrame.forEach(({ id, v }) => {
           const nextOffset = offset + v


### PR DESCRIPTION
Early on when using saka-key I created my list of hint characters, and accidentally entered some twice. While I noticed and changed it eventually, this could have been avoided by making sure the list of `hintChars` only contains unique characters.

I do hope that this is what happens with this change now, but feel free to correct me. I'm not exactly familiar with JS or this codebase.