### PR TITLE
Use firefox native click behavior in versions >= 96

### DIFF
--- a/src/modes/hints/background/index.js
+++ b/src/modes/hints/background/index.js
@@ -5,8 +5,12 @@ import { generateHintStrings } from './hintStrings'
 let hintChars = 'adsfghjkl;'
 let autoActivateHint = false
 
+const firefoxNoNativeClick =
+  SAKA_PLATFORM === 'firefox' &&
+  navigator.userAgent.match(/\bFirefox\/(\d+)/)[1] < 96
+
 export default {
-  onOptionsChange: options => {
+  onOptionsChange: (options) => {
     hintChars = options.hintChars.length >= 2 ? options.hintChars : 'bad'
     autoActivateHint = options.autoActivateHint
   },
@@ -51,56 +55,56 @@ export default {
         }
       } catch (e) {}
     },
-    openLinkInIncognitoWindow: url => {
+    openLinkInIncognitoWindow: (url) => {
       // TODO: consider more robust URL verification like Vimium's
       browser.windows.create({ url, incognito: true })
     },
     // Needed to activate links on firefox because it ignores keyboard modifiers
-    // or doesn't execute default behaviors on click events
-    ...(SAKA_PLATFORM === 'chrome'
-      ? {}
-      : {
-        openLinkInBackgroundTab: url => {
+    // or doesn't execute default behaviors on click events (in versions < 96)
+    ...(firefoxNoNativeClick
+      ? {
+        openLinkInBackgroundTab: (url) => {
           const arg = {
             url: url,
             active: false
           }
           browser.tabs
             .query({ currentWindow: true, active: true })
-            .then(t => {
+            .then((t) => {
               arg.cookieStoreId = t[0].cookieStoreId
             })
             .finally(() => {
               browser.tabs.create(arg)
             })
         },
-        openLinkInForegroundTab: url => {
+        openLinkInForegroundTab: (url) => {
           const arg = {
             url: url,
             active: true
           }
           browser.tabs
             .query({ currentWindow: true, active: true })
-            .then(t => {
+            .then((t) => {
               arg.cookieStoreId = t[0].cookieStoreId
             })
             .finally(() => {
               browser.tabs.create(arg)
             })
         },
-        openLinkInNewWindow: url => {
+        openLinkInNewWindow: (url) => {
           const arg = {
             url: url
           }
           browser.tabs
             .query({ currentWindow: true, active: true })
-            .then(t => {
+            .then((t) => {
               arg.cookieStoreId = t[0].cookieStoreId
             })
             .finally(() => {
               browser.windows.create(arg)
             })
         }
-      })
+      }
+      : {})
   }
 }

--- a/src/modes/hints/client/activate.js
+++ b/src/modes/hints/client/activate.js
@@ -23,10 +23,14 @@ export function activate (event, target) {
  * is selected using hints mode.
  * @type {{ [key: string]: (event: KeyboardEvent, target: HTMLElement) => string }}
  */
+const firefoxNoNativeClick =
+  SAKA_PLATFORM === 'firefox' &&
+  navigator.userAgent.match(/\bFirefox\/(\d+)/)[1] < 96
+
 const activators = {
   openLink: (event, target) => {
     if (
-      SAKA_PLATFORM === 'firefox' &&
+      firefoxNoNativeClick &&
       target.nodeName === 'A' &&
       target.target === '_blank'
     ) {
@@ -40,7 +44,7 @@ const activators = {
   },
   openLinkInBackgroundTab: (event, target) => {
     mouseEvent(target, 'click', { ctrlKey: !isMac, metaKey: isMac })
-    if (SAKA_PLATFORM === 'firefox') {
+    if (firefoxNoNativeClick) {
       backgroundOpenLink('openLinkInBackgroundTab', target)
     }
     target.focus()
@@ -52,7 +56,7 @@ const activators = {
       metaKey: isMac,
       shiftKey: true
     })
-    if (SAKA_PLATFORM === 'firefox') {
+    if (firefoxNoNativeClick) {
       backgroundOpenLink('openLinkInForegroundTab', target)
     }
     target.focus()
@@ -60,7 +64,7 @@ const activators = {
   },
   openLinkInNewWindow: (event, target) => {
     mouseEvent(target, 'click', { shiftKey: true })
-    if (SAKA_PLATFORM === 'firefox') {
+    if (firefoxNoNativeClick) {
       backgroundOpenLink('openLinkInNewWindow', target)
     }
     target.focus()


### PR DESCRIPTION
Here's my attempt at fixing https://github.com/lusakasa/saka-key/issues/335.

Let me first explain my understanding of the issue:

1. There have historically been issues with the "Native Click" behavior in the Firefox browser. When a `MouseEvent` is sent, with "native click" behavior this should trigger the browser to open up a tab in the background, foreground, new window.
2. However, before Firefox version 96.0, this "native click" behavior did not exist, and as a result Saka Key has worked around this by special-casing the firefox browser and [manually triggering the bg/fg behavior](https://github.com/seanjennings960/saka-key/blob/24bb48a3ab99a4818b5c9e7c7d58bf820cbd540d/src/modes/hints/client/activate.js#L48).
3. Firefox version 96.0 (re?)introduced native click functionality, so this special-casing behavior now must only apply to versions <96.0.

This is an equivalent bugfix to https://github.com/philc/vimium/pull/3985.

To me, it seems that `resistFingerprinting` (RFP) is a separate issue (which should only affect the subset of users which have enabled RFP). This is fixed in https://github.com/philc/vimium/pull/4000. I found [the Mozilla bugreport](https://bugzilla.mozilla.org/show_bug.cgi?id=1489903) to be the most enlightening reading on the subject. AFAIU, enabling `resistFingerprinting` is essentially a security measure which causes the `User-Agent` (UA) interface to spoof the Firefox version so that only a subset of Firefox versions are presented to the website. This will causes the UA-based version number check (>96.0) to become unreliable, by reporting (e.g.) v.91.x when the actual version is >v96.0.

I still don't understand the `resistFingerprinting` issue deeply enough to prepare a fix. https:/github.com/philc/vimium/pull/4000 seems to add the additional check that firefox version is [>91.0,<91.5](https://github.com/gdh1995/vimium/blob/dc89e27bcee54b108cf7db13a7f4bb88476c25ca/lib/dom_utils.js#L326), which seems perhaps an improvement, but also not 100% reliable in the non-RFP v91.x case. It also seems to make some other changes to the logic for pulling browser version info that I don't understand.

Regardless, I think the bugfix in this PR is valid on it's own, as it will fix https://github.com/lusakasa/saka-key/issues/335 for non-RFP-enabled users.

The one distasteful addition here is the duplicate reading of `navigator.userAgent.match(/\bFirefox\/(\d+)/)[1] < 96` in both files touched. Please LMK if there's a good way to avoid this, and I can submit a patch.